### PR TITLE
Add GitHub Pages deploy workflow and Go-based markdown converter

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,97 @@
+name: GitHub Pages Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    # Run once a day at 23:00 UTC (morning in AU time, just after usual daily content or as appropriate)
+    - cron: '0 23 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  route:
+    name: Route event
+    runs-on: ubuntu-latest
+    outputs:
+      run_pages: ${{ steps.route.outputs.run_pages }}
+    steps:
+      - id: route
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          run_pages=false
+
+          case "${{ github.event_name }}" in
+            push)
+              run_pages=true
+              ;;
+            workflow_dispatch)
+              run_pages=true
+              ;;
+            schedule)
+              run_pages=true
+              ;;
+          esac
+
+          echo "run_pages=$run_pages" >> "$GITHUB_OUTPUT"
+
+  gitleaks:
+    name: Secret scan
+    needs: [route]
+    if: ${{ needs.route.outputs.run_pages == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-and-deploy:
+    name: Build and Deploy
+    needs: [route, gitleaks]
+    if: ${{ needs.route.outputs.run_pages == 'true' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build Pages
+        run: |
+          mkdir -p public
+          # Generate HTML
+          go run scripts/build-pages.go readme.md public/index.html
+
+          # Generate RSS Feeds using the main utility
+          go run ./cmd/whirlpoolforumrss -action newthreads -output public/newthreads.xml
+          go run ./cmd/whirlpoolforumrss -action popular_views -output public/popular_views.xml
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './public'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist
 
+public/

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/arran4/whirlpool-forum-rss
 
 go 1.25.0
 
-require github.com/PuerkitoBio/goquery v1.12.0
+require (
+	github.com/PuerkitoBio/goquery v1.12.0
+	github.com/yuin/goldmark v1.4.13
+)
 
 require (
 	github.com/andybalholm/cascadia v1.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YF
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/scripts/build-pages.go
+++ b/scripts/build-pages.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/yuin/goldmark"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Println("Usage: go run build-pages.go <input-md> <output-html>")
+		os.Exit(1)
+	}
+
+	inputFile := os.Args[1]
+	outputFile := os.Args[2]
+
+	md, err := os.ReadFile(inputFile)
+	if err != nil {
+		fmt.Printf("Error reading input file: %v\n", err)
+		os.Exit(1)
+	}
+
+	var buf bytes.Buffer
+	// Add some basic HTML wrapper
+	buf.WriteString("<!DOCTYPE html>\n<html>\n<head>\n<meta charset=\"utf-8\">\n<title>Whirlpool Forum RSS</title>\n</head>\n<body>\n")
+
+	if err := goldmark.Convert(md, &buf); err != nil {
+		fmt.Printf("Error converting markdown: %v\n", err)
+		os.Exit(1)
+	}
+
+	buf.WriteString("</body>\n</html>\n")
+
+	err = os.MkdirAll(filepath.Dir(outputFile), 0755)
+	if err != nil {
+		fmt.Printf("Error creating output directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = os.WriteFile(outputFile, buf.Bytes(), 0644)
+	if err != nil {
+		fmt.Printf("Error writing output file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Successfully converted %s to %s\n", inputFile, outputFile)
+}


### PR DESCRIPTION
Adds a GitHub Pages action deploy to github pages script that converts the readme to HTML and publishes the generated RSS feeds. It runs manually and on a schedule.

---
*PR created automatically by Jules for task [5104499797310176900](https://jules.google.com/task/5104499797310176900) started by @arran4*