### PR TITLE
Add category tags to RSS feed items

### DIFF
--- a/whirlpoolforumrss.go
+++ b/whirlpoolforumrss.go
@@ -95,7 +95,7 @@ Last Post: {{.LastPostAuthor}} ({{.LastPostTime}})`
 			pubDate = time.Now()
 		}
 
-		var categories []string
+		categories := make([]string, 0, 2)
 		if section != "" {
 			categories = append(categories, section)
 		}

--- a/whirlpoolforumrss.go
+++ b/whirlpoolforumrss.go
@@ -24,11 +24,12 @@ type Channel struct {
 }
 
 type Item struct {
-	Title       string `xml:"title"`
-	Link        string `xml:"link"`
-	Description string `xml:"description"`
-	PubDate     string `xml:"pubDate"`
-	GUID        string `xml:"guid"`
+	Title       string   `xml:"title"`
+	Link        string   `xml:"link"`
+	Description string   `xml:"description"`
+	PubDate     string   `xml:"pubDate"`
+	GUID        string   `xml:"guid"`
+	Categories  []string `xml:"category,omitempty"`
 }
 
 func GenerateRSS(action string) ([]byte, error) {
@@ -94,12 +95,21 @@ Last Post: {{.LastPostAuthor}} ({{.LastPostTime}})`
 			pubDate = time.Now()
 		}
 
+		var categories []string
+		if section != "" {
+			categories = append(categories, section)
+		}
+		if tag != "" {
+			categories = append(categories, tag)
+		}
+
 		items = append(items, Item{
 			Title:       fmt.Sprintf("[%s] %s", section, title),
 			Link:        fmt.Sprintf("https://forums.whirlpool.net.au%s", archiveLink),
 			Description: descriptionBuilder.String(),
 			PubDate:     pubDate.Format(time.RFC1123),
 			GUID:        fmt.Sprintf("https://forums.whirlpool.net.au%s", topicLink),
+			Categories:  categories,
 		})
 	})
 


### PR DESCRIPTION
Added a `Categories` field to the `Item` struct mapped to the `xml:"category"` tag. Populated this slice with the extracted `section` and `tag` values when generating the RSS feed. This allows feed readers to appropriately categorize and filter the Whirlpool forum topics.

---
*PR created automatically by Jules for task [4967625904305747742](https://jules.google.com/task/4967625904305747742) started by @arran4*