### PR TITLE
ci: fix golangci-lint go version mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,9 +274,9 @@ jobs:
       with:
         go-version-file: go.mod
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v9
       with:
-        version: v1.64.6
+        version: latest
 
   go-test:
     name: Go lint/test (${{ matrix.os }})


### PR DESCRIPTION
This commit resolves a CI failure where `golangci-lint` fails to run due to a Go version mismatch (the linter was built with go1.24 but the project targets 1.25.0). 

Following the instructions from [Arrans Technical Blog](https://arran4.github.io/blog/post/2026/015-llm-instructions-golangci-lint-version-conflicts/), the `golangci/golangci-lint-action` has been updated to `v9` and the `golangci-lint` version is set to `latest`. The project already correctly uses `go-version-file: go.mod` to sync the Go version.

---
*PR created automatically by Jules for task [16065678103367341802](https://jules.google.com/task/16065678103367341802) started by @arran4*