### PR TITLE
fix: improve resilience during site directory generation and RSS scraping

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,7 @@ jobs:
           cat readme.html >> public/index.html
           echo '</html>' >> public/index.html
           # Generate RSS feed
-          go run ./cmd/whirlpoolforumrss -output public/rss/whirlpoolforumrss.xml || curl -fLo public/rss/whirlpoolforumrss.xml https://arran4.github.io/whirlpool-forum-rss/rss/whirlpoolforumrss.xml || true
+          go run ./cmd/whirlpoolforumrss -output public/rss/whirlpoolforumrss.xml || curl -fLo public/rss/whirlpoolforumrss.xml https://arran4.github.io/whirlpool-forum-rss/rss/whirlpoolforumrss.xml
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,7 @@ jobs:
           cat readme.html >> public/index.html
           echo '</html>' >> public/index.html
           # Generate RSS feed
-          go run ./cmd/whirlpoolforumrss -output public/rss/whirlpoolforumrss.xml
+          go run ./cmd/whirlpoolforumrss -output public/rss/whirlpoolforumrss.xml || curl -fLo public/rss/whirlpoolforumrss.xml https://arran4.github.io/whirlpool-forum-rss/rss/whirlpoolforumrss.xml || true
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/whirlpoolforumrss.go
+++ b/whirlpoolforumrss.go
@@ -36,14 +36,38 @@ func GenerateRSS(action string) ([]byte, error) {
 	baseURL := "https://forums.whirlpool.net.au/forum/"
 	url := fmt.Sprintf("%s?action=%s", baseURL, action)
 
-	resp, err := http.Get(url)
+	var resp *http.Response
+	var err error
+	maxRetries := 3
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		req, reqErr := http.NewRequest("GET", url, nil)
+		if reqErr != nil {
+			return nil, fmt.Errorf("failed to create request: %w", reqErr)
+		}
+		req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36")
+
+		resp, err = http.DefaultClient.Do(req)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			break
+		}
+
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+
+		if attempt < maxRetries {
+			time.Sleep(5 * time.Second)
+		}
+	}
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch forum page: %w", err)
+		return nil, fmt.Errorf("failed to fetch forum page after %d attempts: %w", maxRetries, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return nil, fmt.Errorf("unexpected status code: %d after %d attempts", resp.StatusCode, maxRetries)
 	}
 
 	doc, err := goquery.NewDocumentFromReader(resp.Body)


### PR DESCRIPTION
- Add a standard User-Agent header and a 3-attempt retry loop to the HTTP client in `whirlpoolforumrss.go` to prevent 403 Forbidden errors when scraping the forum.
- Update the RSS generation step in `.github/workflows/pages.yml` to fall back to downloading the most recently published version of the RSS feed if the scrape fails.

---
*PR created automatically by Jules for task [4848992920625080022](https://jules.google.com/task/4848992920625080022) started by @arran4*